### PR TITLE
Add reset slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The bot will log in to Discord and begin listening for mentions. Conversation lo
 ## Usage
 
 Invite the bot to your server and mention it in a channel. When you tag the bot with a question or message, it will reply in the style of SHODAN. Messages and replies are stored so that follow-up conversations maintain context (up to a limit of recent turns).
+Use the `/reset` slash command to clear the saved history for the current channel if you want to start fresh.
 
 ## License
 


### PR DESCRIPTION
## Summary
- register `/reset` on startup using `SlashCommandBuilder`
- clear history in memory and on disk when `/reset` is run
- document the new command in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845b1935b888323af2b62eb20c55392